### PR TITLE
add requirements file

### DIFF
--- a/field_application/requirements.txt
+++ b/field_application/requirements.txt
@@ -1,0 +1,4 @@
+Django==1.5.1
+django-like==0.2.0
+psycopg2==2.6.1
+wheel==0.24.0


### PR DESCRIPTION
增加 pip 用的 requirements file
其他人clone项目下来后，pip install -r requirements.txt 即可安装依赖
不过安装psycopg2前，还要先用 apt-get 安装 libpq-dev
